### PR TITLE
Link only work item ID in reading mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -148,9 +148,24 @@ var DevOpsLinkPlugin = class extends import_obsidian2.Plugin {
       const workItemId = ((_d = (_c = (_b = match.groups) == null ? void 0 : _b.id) != null ? _c : match[1]) != null ? _d : "").trim();
       const workItemUrl = workItemId ? this.buildWorkItemUrl(workItemId) : null;
       if (workItemUrl) {
-        fragment.append(
-          this.createLinkElement(matchText, workItemUrl, workItemId)
-        );
+        const idIndex = matchText.indexOf(workItemId);
+        if (idIndex === -1) {
+          fragment.append(
+            this.createLinkElement(matchText, workItemUrl, workItemId)
+          );
+        } else {
+          const prefixText = matchText.slice(0, idIndex);
+          const suffixText = matchText.slice(idIndex + workItemId.length);
+          if (prefixText) {
+            fragment.append(prefixText);
+          }
+          fragment.append(
+            this.createLinkElement(workItemId, workItemUrl, workItemId)
+          );
+          if (suffixText) {
+            fragment.append(suffixText);
+          }
+        }
       } else {
         fragment.append(matchText);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,9 +93,28 @@ export default class DevOpsLinkPlugin extends Plugin {
         : null;
 
       if (workItemUrl) {
-        fragment.append(
-          this.createLinkElement(matchText, workItemUrl, workItemId)
-        );
+        const idIndex = matchText.indexOf(workItemId);
+
+        if (idIndex === -1) {
+          fragment.append(
+            this.createLinkElement(matchText, workItemUrl, workItemId)
+          );
+        } else {
+          const prefixText = matchText.slice(0, idIndex);
+          const suffixText = matchText.slice(idIndex + workItemId.length);
+
+          if (prefixText) {
+            fragment.append(prefixText);
+          }
+
+          fragment.append(
+            this.createLinkElement(workItemId, workItemUrl, workItemId)
+          );
+
+          if (suffixText) {
+            fragment.append(suffixText);
+          }
+        }
       } else {
         fragment.append(matchText);
       }


### PR DESCRIPTION
## Summary
- update the markdown post-processor to link only the matched work item ID while leaving surrounding markup as plain text
- rebuild the compiled plugin bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ca1cf8e1c4832bb4e79b6b6fe6c504