### PR TITLE
Show only work item ID in rendered links

### DIFF
--- a/main.js
+++ b/main.js
@@ -148,24 +148,9 @@ var DevOpsLinkPlugin = class extends import_obsidian2.Plugin {
       const workItemId = ((_d = (_c = (_b = match.groups) == null ? void 0 : _b.id) != null ? _c : match[1]) != null ? _d : "").trim();
       const workItemUrl = workItemId ? this.buildWorkItemUrl(workItemId) : null;
       if (workItemUrl) {
-        const idIndex = matchText.indexOf(workItemId);
-        if (idIndex === -1) {
-          fragment.append(
-            this.createLinkElement(matchText, workItemUrl, workItemId)
-          );
-        } else {
-          const prefixText = matchText.slice(0, idIndex);
-          const suffixText = matchText.slice(idIndex + workItemId.length);
-          if (prefixText) {
-            fragment.append(prefixText);
-          }
-          fragment.append(
-            this.createLinkElement(workItemId, workItemUrl, workItemId)
-          );
-          if (suffixText) {
-            fragment.append(suffixText);
-          }
-        }
+        fragment.append(
+          this.createLinkElement(workItemId, workItemUrl, workItemId)
+        );
       } else {
         fragment.append(matchText);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,28 +93,9 @@ export default class DevOpsLinkPlugin extends Plugin {
         : null;
 
       if (workItemUrl) {
-        const idIndex = matchText.indexOf(workItemId);
-
-        if (idIndex === -1) {
-          fragment.append(
-            this.createLinkElement(matchText, workItemUrl, workItemId)
-          );
-        } else {
-          const prefixText = matchText.slice(0, idIndex);
-          const suffixText = matchText.slice(idIndex + workItemId.length);
-
-          if (prefixText) {
-            fragment.append(prefixText);
-          }
-
-          fragment.append(
-            this.createLinkElement(workItemId, workItemUrl, workItemId)
-          );
-
-          if (suffixText) {
-            fragment.append(suffixText);
-          }
-        }
+        fragment.append(
+          this.createLinkElement(workItemId, workItemUrl, workItemId)
+        );
       } else {
         fragment.append(matchText);
       }


### PR DESCRIPTION
## Summary
- remove the markup prefix and suffix so rendered work item links only display the numeric identifier
- rebuild the bundled plugin output to include the updated rendering logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ca1f7d3150832bba404e6f6e27ef73